### PR TITLE
Add Dependabot definition for github-actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "14:00"
+      timezone: "Asia/Tokyo"
+    reviewers:
+      - "increments/developers"


### PR DESCRIPTION
## What
Dependabot に github-actionsの定義を追加する。

## Why
Dependabotの設定を行うことで、GitHub Actionsに依存する定義を更新できるようにするため