### PR TITLE
Remove reviewers definition from dependabot settings file 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,3 @@ updates:
       day: "monday"
       time: "14:00"
       timezone: "Asia/Tokyo"
-    reviewers:
-      - "increments/developers"


### PR DESCRIPTION
## What
Remove reviewers definition from dependabot settings file.

## Why
To avoid specifying a team for public repositories.