### PR TITLE
Add cooldown configuration to Dependabot with 7-day delay

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       interval: "weekly"
       day: "sunday"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## What

- Add cooldown configuration to Dependabot with 7-day delay